### PR TITLE
Fix wrong address.

### DIFF
--- a/i2pkeys/I2PAddr.go
+++ b/i2pkeys/I2PAddr.go
@@ -160,11 +160,7 @@ func NewI2PAddrFromBytes(addr []byte) (I2PAddr, error) {
 
 // Turns an I2P address to a byte array. The inverse of NewI2PAddrFromBytes().
 func (addr I2PAddr) ToBytes() ([]byte, error) {
-	buf := make([]byte, i2pB64enc.DecodedLen(len(addr)))
-	if _, err := i2pB64enc.Decode(buf, []byte(addr)); err != nil {
-		return buf, errors.New("Address is not base64-encoded")
-	}
-	return buf, nil
+	return i2pB64enc.DecodeString(string(addr))
 }
 
 func (addr I2PAddr) Bytes() []byte {


### PR DESCRIPTION
With some addresses, ToBytes() calculates the wrong buffer lenngth
and returns the larger buffer for next step (sha256). So the b32
address will wrong.

For example, when the b64 key is the following:

```tr2kQArAdxb7rt3Hr6itisY1Pi7ncWVUYDan2rjB45F1lIFvDPJih5dBa~WfWTvfyt
QKdtFoGHLuZdC8X71R5GXGvh8N0ECBtjhYPG8chFSEO2Cab2SZKYskEqGeOrlOvAQ-
yYaH0xCkarxFdvEbXoV~cfDhHDJcZI3Uc522sLWlB72-uOH9nlzyt-41byGc5GWn5c
CxJZx8UfszUIG9B2QoptrN0xquWvkLxescZ~0JYePTEJTeQFWlfPAiHcuAloAq3yKt
DCY4xcSracQr9ieCmnFJoUsLtzsjSrn7L~WwlI4pYYXxkm2dtzR8cPHJCBUBNMbK~K
TIxLtH0Tt9wI3edHgRMdxNm3EoozpPMXA05Ouni~ehWMhaywiJKTDZcGKDRqXJVm~y
xJGcXiXT2UzdwM~D20KTTUlLmeRqsU5hqpk2kgBIWKFfb8Gunx2hr0wEHsJypUwDQ-
FSGT0Fw0MRGq0QWvwXxroPbJdjsNnYOKCEogHxC4VrmzaLhHlEBQAEAAcAAA==
```

the right raw key length is 391, but ToBytes() returns a 393 bytes
raw key.

Using DecodeString() can fix this issue.