### PR TITLE
logging naming convention hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ export DEBUG_I2P=warn
 export DEBUG_I2P=error
 ```
 
-If in case I2P_DEBUG is set to an unrecognized variable, it will fall back to "debug".
+If I2P_DEBUG is set to an unrecognized variable, it will fall back to "debug".
 
 ## License ##
 

--- a/log.go
+++ b/log.go
@@ -13,7 +13,7 @@ var (
 	once sync.Once
 )
 
-func InitializeLogger() {
+func InitializeSAM3Logger() {
 	once.Do(func() {
 		log = logrus.New()
 		// We do not want to log by default
@@ -37,14 +37,14 @@ func InitializeLogger() {
 	})
 }
 
-// GetLogger returns the initialized logger
-func GetLogger() *logrus.Logger {
+// GetSAM3Logger returns the initialized logger
+func GetSAM3Logger() *logrus.Logger {
 	if log == nil {
-		InitializeLogger()
+		InitializeSAM3Logger()
 	}
 	return log
 }
 
 func init() {
-	InitializeLogger()
+	InitializeSAM3Logger()
 }

--- a/sam3.go
+++ b/sam3.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	InitializeLogger()
+	InitializeSAM3Logger()
 }
 
 // Used for controlling I2Ps SAMv3.

--- a/suggestedOptions.go
+++ b/suggestedOptions.go
@@ -99,7 +99,7 @@ func PrimarySessionString() string {
 var PrimarySessionSwitch string = PrimarySessionString()
 
 func getEnv(key, fallback string) string {
-	InitializeLogger()
+	InitializeSAM3Logger()
 	value, ok := os.LookupEnv(key)
 	if !ok {
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
There is a naming collision that conflicts with the same logging paradigm found in go-i2p and i2pkeys. So we require renaming the logger functions in order for the libs to work together.